### PR TITLE
Allow for namespaced thrift contracts

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -5,3 +5,4 @@ Kartik Vishwanath
 Josh Murphy
 Adam Stegman
 Michael Brailsford
+Al May

--- a/bin/scrimp
+++ b/bin/scrimp
@@ -32,11 +32,11 @@ Dir.mktmpdir do |out|
   folders = files.map {|file| File.dirname(File.expand_path(file))}.uniq
   include_directives = folders.map {|dir| "-I #{dir}"}.join(' ')
   files.each do |file|
-    puts (cmd = "#{options[:thrift_command]} --gen rb -out #{out} #{include_directives} #{file}")
+    puts (cmd = "#{options[:thrift_command]} --gen rb:namespaced -out #{out} #{include_directives} #{file}")
     puts `#{cmd}`
   end
   $LOAD_PATH.unshift out
-  Dir["#{out}/*.rb"].each {|file| require file}
+  Dir["#{out}/**/*.rb"].each {|file| require file }
   $LOAD_PATH.delete out
 end
 


### PR DESCRIPTION
added the rb:namespaced option to the command-line thrift invocation
made corresponding change to 'require' iteration to no longer assume a flat directory tree