### PR TITLE
Including a require 'thrift' statement in the sample/server.rb file

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -6,3 +6,4 @@ Josh Murphy
 Adam Stegman
 Michael Brailsford
 Al May
+Jason Shar

--- a/sample/server.rb
+++ b/sample/server.rb
@@ -2,6 +2,7 @@
 
 require 'optparse'
 require 'tmpdir'
+require 'thrift'
 
 options = {port: 9000,
            thrift_command: 'thrift'}


### PR DESCRIPTION
Was going through the README example server and would get an error: 

```
js025394@MAC1514754:~/git/scrimp (master) $ bundle exec sample/server.rb -t /usr/local/bin/thrift 
/usr/local/bin/thrift --gen rb --out /var/folders/m9/bv45s8ns1w10smk_g8qv8yp8j5gchq/T/d20160921-96464-dzaiqk /Users/js025394/git/scrimp/sample/example.thrift

/var/folders/m9/bv45s8ns1w10smk_g8qv8yp8j5gchq/T/d20160921-96464-dzaiqk/example_types.rb:17:in `<class:WordStats>': uninitialized constant Thrift (NameError)
    from /var/folders/m9/bv45s8ns1w10smk_g8qv8yp8j5gchq/T/d20160921-96464-dzaiqk/example_types.rb:16:in `<top (required)>'
    from /var/folders/m9/bv45s8ns1w10smk_g8qv8yp8j5gchq/T/d20160921-96464-dzaiqk/example_constants.rb:7:in `require'
    from /var/folders/m9/bv45s8ns1w10smk_g8qv8yp8j5gchq/T/d20160921-96464-dzaiqk/example_constants.rb:7:in `<top (required)>'
    from sample/server.rb:33:in `require'
    from sample/server.rb:33:in `block (2 levels) in <main>'
    from sample/server.rb:33:in `each'
    from sample/server.rb:33:in `block in <main>'
    from /Users/js025394/.rvm/rubies/ruby-2.2.1/lib/ruby/2.2.0/tmpdir.rb:88:in `mktmpdir'
    from sample/server.rb:28:in `<main>'
```

Adding this in seemed to fix the problem and I could continue with the example. I am using thrift 0.9.3 and this would occur with both ruby versions 2.2.1 and 1.9.3-p551
